### PR TITLE
改LANG的參數

### DIFF
--- a/程式/對齊合成.py
+++ b/程式/對齊合成.py
@@ -98,7 +98,7 @@ class 對齊合成(腳本程式):
 			參數量 = 24
 		else:
 			參數量 = 40
-		HTS設定指令 = '''LANG=c ./configure --with-sptk-search-path={0} \
+		HTS設定指令 = '''LANG=C ./configure --with-sptk-search-path={0} \
 --with-hts-search-path={1} \
 --with-hts-engine-search-path={2} \
 LOWERF0=60 UPPERF0=500 SAMPFREQ={3} FRAMELEN={4} FRAMESHIFT={5} \
@@ -106,5 +106,5 @@ GAMMA=3 LNGAIN=1 MGCORDER={6} USEGV=0'''\
 			.format(SPTK執行檔路徑, HTS執行檔路徑, HTS_ENGINE執行檔路徑,
 				頻率, 音框長度, 音框移動, 參數量)
 		self.走指令(HTS設定指令)
-		HTS走指令 = 'LANG=c make all'
+		HTS走指令 = 'LANG=C make all'
 		self.走指令(HTS走指令)


### PR DESCRIPTION
因為會出現

```
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
        LANGUAGE = (unset),
        LC_ALL = (unset),
        LANG = "c"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
```

所以改大寫 丞宏
